### PR TITLE
Modify code to allow :initform to be used for unspecified fields.

### DIFF
--- a/jeison.el
+++ b/jeison.el
@@ -168,7 +168,8 @@ proceed with a nested JSON further on."
             ;; not a special case of parsing - return whatever we found
             (_ json))))
     ;; check that the parsed value matches the expected type...
-    (or (cl-typep result type)
+    (or (null result)
+        (cl-typep result type)
         (signal 'jeison-wrong-parsed-type
                 (list type result)))
     ;; ...and return it if it does
@@ -226,10 +227,13 @@ in the target class' constructor:
 SLOT is a jeison descriptor of an slot, i.e. `jeison--slot'.
 JSON is an `alist' representing a JSON object where we want information
 to be parsed from."
-  (list (or (oref slot initarg)
-            (oref slot name))
-        (jeison--read-internal
-         (oref slot type) json (oref slot path))))
+  (let ((slot-value (jeison--read-internal
+                     (oref slot type) json (oref slot path))))
+    (if (null slot-value)
+        nil
+      (list (or (oref slot initarg)
+                (oref slot name))
+            slot-value))))
 
 (defun jeison--read-path (json path)
   "Return nested JSON object found by the given list of keys PATH.


### PR DESCRIPTION
When specifying a class slot, we're allowed to pass an :initform
specifying a form to use as the initial value of the slot when it's
not passed to the constructor.

Currently, if we we specify a slot with jeison-defclass, the behavior
is to require that field be present in the decoded json. This is a
problem for situations where fields may have a default value, but that
default isn't necessarily encoded in the payload (eg: gRPC). Thus we
change the default behavior to allow fields to not be present.

This is a two part fix:
  1) modify jeison--read-internal to allow null fields to skip type check
  2) modify jeison--read-slot to return nil when a slot value is null

Then, when jeison--read-class applies the constructor to initialization
values, the unspecified fields will be absent and the constructor will
use their :initform instead.